### PR TITLE
Empty response body

### DIFF
--- a/src/superstructor/re_frame/fetch_fx.cljs
+++ b/src/superstructor/re_frame/fetch_fx.cljs
@@ -224,7 +224,8 @@
   [request js-response]
   (let [response                       (js-response->clj js-response)
         {:keys [reader-kw] :as reader} (response->reader request response)]
-    (if (= "0" (get-in response [:headers :content-length]))
+    (if (or (= "0" (get-in response [:headers :content-length]))
+            (= 204 (:status response)))
       (body-success-handler request
                             response
                             {:reader-fn identity}


### PR DESCRIPTION
Hello!

Thanks so much for creating this library, it's fantastic :grin:

This PR accounts for a couple of cases where it may not make sense to parse the response body, when the content-length of the response is 0 or when the response code is 204.

Arguably the server should not return a `Content-Type: application/json` header for a 0 byte body or in the case of a 204 should return `Content-Length: 0` but makes the response handling more permissive in bypassing parsing in the two cases above.

Let me know what you think or if you would like the implementation to take a different approach.