### PR TITLE
Remove space when creating seq of effect in abort-fx

### DIFF
--- a/src/superstructor/re_frame/fetch_fx.cljs
+++ b/src/superstructor/re_frame/fetch_fx.cljs
@@ -294,7 +294,7 @@
 
 (defn abort-fx
   [effect]
-  (let [seq-of-effects (-> seq effect)]
+  (let [seq-of-effects (->seq effect)]
     (doseq [effect seq-of-effects]
       (abort effect))))
 


### PR DESCRIPTION
Fixed issue in abort-fx where there was an space that broke the '->seq'-function