### PR TITLE
Add support for external AbortSignals

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -167,7 +167,13 @@ All possible values of a `:fetch` map.
                                       #"image/.*"                :blob
                                       "application/octet-stream" :array-buffer}
 
-             ;; for :fetch/abort
+             ;; Optional. If you want to associate multiple requests with a single
+             ;; AbortSignal you can pass it as value for the :abort-signal and use your own
+             ;; (external) AbortController to handle aborts.
+             :abort-signal            (.-signal (js/AbortController)
+
+             ;; Use :request-id with ::abort effect to abort the request
+             ;; Note: when using :abort-signal you cannot abort the request using :request-id
              :request-id             :my-custom-request-id
              ;; or auto-generated
              :on-request-id          [:fetch-request-id]
@@ -176,6 +182,25 @@ All possible values of a `:fetch` map.
 
              :on-failure             [:bad-fetch-result]}}))
 ```
+
+== Aborting Requests
+There are two different ways you can abort requests:
+
+ * Abort a (single) request by passing its **request-id** to the `::abort` effect:
+```
+(reg-event-fx
+  :abort-request
+  (fn [_ [request-id]]
+    {::abort {:request-id request-id}}))
+```
+**Note:** Reusing the same request-id for multiple different requests **will not work**.
+          The `::abort` effect would only abort the last of these requests.
+
+* Abort multiple requests by using an external **AbortController**. Pass the AbortController's  **AbortSignal** instance
+as value for the `:abort-signal` inside the `::fetch` effect map.
+
+**Note**: When you decide to use an external AbortController by passing its `:abort-signal`
+          in the `::fetch` map, you **cannot** abort this request via the `::abort` effect anymore.
 
 == Success Handling
 


### PR DESCRIPTION
Hi,

thanks for this great library, it's much appreciated 🙏 

I came across a use case recently, where I had to deal with groups of requests and also needed to abort requests on the "group level". Looking at the Fetch API, I found that the easiest way to achieve this is by passing the signal of a single AbortController instance to all requests of such a group. 

Currently, this library creates a dedicated AbortController instance per request, which made the scenario mentioned above a bit difficult to implement. I adapted the library for my use case, by adding an optional `:abort-signal` to the `:fetch` map. This allows the user to opt out of the internal request abort handling and to bring their own AbortController. 

I thought this feature might come in handy for others as well, so here we go :)

**Pros**: 
* More flexibility for the user concerning request aborting
* Multiple requests can be handled by a single AbortController
* Convenience feature for highly asynchronous use cases: when trying to dispatch a request using a signal that was already aborted, the request is never dispatched.  

**Cons**:
* It might be confusing for users when there are two mutually exclusive ways to abort requests. 